### PR TITLE
Changed Betfair host to DNS entry.

### DIFF
--- a/src/lib/invocation.js
+++ b/src/lib/invocation.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const HttpRequest = require('./http_request.js');
 
 // BETFAIR API enpoints
-const BETFAIR_API_HOST = 'https://84.20.200.10:443';
+const BETFAIR_API_HOST = 'https://api.betfair.com:443';
 const BETFAIR_API_ENDPOINTS = {
     accounts: {
         type: "AccountAPING",


### PR DESCRIPTION
The SSL cert on the previous IP address has expired and have contacted Betfair and they have decommissioned that server.
The API is failing as a result of the expired cert, changing to DNS resolves the issue.